### PR TITLE
Use connectTimeout and readTimeout configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Extensions
 List of known extension
 * [Google](https://github.com/grails-plugins/grails-spring-security-oauth2-google)
 * [Facebook](https://github.com/MatrixCrawler/grails-spring-security-oauth2-facebook)
-* [Github] (https://github.com/rpalcolea/grails-spring-security-oauth2-github)
+* [Github](https://github.com/rpalcolea/grails-spring-security-oauth2-github)
+* [Outlook](https://github.com/andreperegrina/grails-spring-security-oauth2-outlook)
 
 
 How to create a new provider plugin

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ List of known extension
 * [Facebook](https://github.com/MatrixCrawler/grails-spring-security-oauth2-facebook)
 * [Github](https://github.com/rpalcolea/grails-spring-security-oauth2-github)
 * [Outlook](https://github.com/andreperegrina/grails-spring-security-oauth2-outlook)
+* [VK](https://github.com/purpleraven/grails-spring-security-oauth2-vk)
+* [Odnoklassniki](https://github.com/purpleraven/grails-spring-security-oauth2-ok)
 
 
 How to create a new provider plugin

--- a/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
@@ -149,6 +149,12 @@ class SpringSecurityOauth2BaseService {
             if (apiSecret == null || apiSecret.isEmpty()) {
                 throw new OAuth2Exception("API Secret for provider '" + providerService.providerID + "' is missing")
             }
+
+            def connectTimeout = getConfigValue(providerService.providerID, "connectTimeout") as Integer
+            def readTimeout = getConfigValue(providerService.providerID, "readTimeout") as Integer
+
+            log.debug("connectTimeout: $connectTimeout, readTimeout: $readTimeout")
+
             _providerConfigurationMap.put(providerService.providerID, new OAuth2ProviderConfiguration(
                     apiKey: apiKey,
                     apiSecret: apiSecret,
@@ -156,7 +162,9 @@ class SpringSecurityOauth2BaseService {
                     successUrl: successUrl,
                     failureUrl: failureUrl,
                     scope: scopes ? providerService.getScopes() + providerService.scopeSeparator + scopes : providerService.getScopes(),
-                    debug: grailsApplication.config.getProperty('oauth2.debug') ? grailsApplication.config.getProperty('oauth2.debug') : false
+                    debug: grailsApplication.config.getProperty('oauth2.debug') ? grailsApplication.config.getProperty('oauth2.debug') : false,
+                    connectTimeout:connectTimeout,
+                    readTimeout:readTimeout
             ))
             providerService.init(_providerConfigurationMap.get(providerService.providerID))
             providerServiceMap.put(providerService.providerID, providerService)

--- a/src/main/groovy/grails/plugin/springsecurity/oauth2/service/OAuth2AbstractProviderService.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/oauth2/service/OAuth2AbstractProviderService.groovy
@@ -110,6 +110,8 @@ abstract class OAuth2AbstractProviderService implements OAuth2ProviderService {
                 .apiKey(providerConfiguration.apiKey)
                 .apiSecret(providerConfiguration.apiSecret)
                 .state(secretState)
+                .connectTimeout(providerConfiguration.connectTimeout).readTimeout(providerConfiguration.readTimeout)
+
         if (providerConfiguration.callbackUrl) {
             serviceBuilder.callback(providerConfiguration.callbackUrl)
         }

--- a/src/main/groovy/grails/plugin/springsecurity/oauth2/util/OAuth2ProviderConfiguration.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/oauth2/util/OAuth2ProviderConfiguration.groovy
@@ -41,4 +41,8 @@ class OAuth2ProviderConfiguration {
     String successUrl
 
     String failureUrl
+
+    Integer connectTimeout
+
+    Integer readTimeout
 }


### PR DESCRIPTION
scribejava supports connectTimeout and readTimeout

Couple days ago my service was locked because of many threads with facebook calls. 

The callback connection never be terminated with current implementation 
