### PR TITLE
Remove deprecated class and allow OAuth servers running on localhost

### DIFF
--- a/grails-app/controllers/grails/plugin/springsecurity/oauth2/SpringSecurityOAuth2Controller.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/oauth2/SpringSecurityOAuth2Controller.groovy
@@ -55,7 +55,8 @@ class SpringSecurityOAuth2Controller {
         log.debug "authenticate ${providerName}"
         String url = springSecurityOauth2BaseService.getAuthorizationUrl(providerName)
         log.debug "redirect url from s2oauthservice=${url}"
-        if (!UrlValidator.instance.isValid(url)) {
+        UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS)
+        if (!urlValidator.isValid(url)) {
             flash.message = "Authorization url for provider '${providerName}' is invalid."
             redirect(controller: 'login', action: 'index')
         }

--- a/grails-app/controllers/grails/plugin/springsecurity/oauth2/SpringSecurityOAuth2Controller.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/oauth2/SpringSecurityOAuth2Controller.groovy
@@ -25,7 +25,7 @@ import grails.plugin.springsecurity.userdetails.GrailsUser
 import groovy.util.logging.Slf4j
 import org.apache.commons.lang.StringUtils
 import org.apache.commons.lang.exception.ExceptionUtils
-import org.grails.validation.routines.UrlValidator
+import org.apache.commons.validator.routines.UrlValidator
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.servlet.ModelAndView
 


### PR DESCRIPTION
I replaced the import of the deprecated `org.grails.validation.routines.UrlValidator` with the newer `org.apache.commons.validator.routines.UrlValidator`.

And I changed `UrlValidator` so that it allows localhost URLs i.e. `http://localhost:8080` to be used so that developers can use the plugin with OAuth 2 servers that are running on their localhost.