### PR TITLE
Fix TravisCI builds by changing the JDK used to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 branches:
   only:
   - master


### PR DESCRIPTION
An attempt at fixing TravisCI builds by changing the JDK used to openjdk8