### PR TITLE
Grails 4 compatible plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build/
 
 # Ignore Gradle GUI config
 gradle-app.setting
-gradle.properties
+# gradle.properties
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 branches:
   only:
   - master

--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,7 @@ dependencyManagement {
 }
 
 dependencies {
-	compile 'com.ning:async-http-client:1.9.38'
-	compile 'org.asynchttpclient:async-http-client:2.0.4'
-	compile 'com.github.scribejava:scribejava-apis:2.7.3'
+	compile 'com.github.scribejava:scribejava-apis:6.8.1'
 
 	console "org.grails:grails-console"
 

--- a/grails-app/conf/logback.groovy
+++ b/grails-app/conf/logback.groovy
@@ -8,7 +8,7 @@ appender('STDOUT', ConsoleAppender) {
     }
 }
 
-logger 'grails.plugin.springsecurity.oauth2', TRACE
+//logger 'grails.plugin.springsecurity.oauth2', TRACE
 root(ERROR, ['STDOUT'])
 
 def targetDir = BuildSettings.TARGET_DIR

--- a/grails-app/controllers/grails/plugin/springsecurity/oauth2/SpringSecurityOAuth2Controller.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/oauth2/SpringSecurityOAuth2Controller.groovy
@@ -25,7 +25,7 @@ import grails.plugin.springsecurity.userdetails.GrailsUser
 import groovy.util.logging.Slf4j
 import org.apache.commons.lang.StringUtils
 import org.apache.commons.lang.exception.ExceptionUtils
-import org.grails.validation.routines.UrlValidator
+import org.apache.commons.validator.routines.UrlValidator
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.servlet.ModelAndView
 

--- a/grails-app/controllers/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2UrlMappings.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2UrlMappings.groovy
@@ -10,6 +10,7 @@ class SpringSecurityOauth2UrlMappings {
         def active = Holders.grailsApplication.config.grails?.plugin?.springsecurity?.oauth2?.active
         def enabled = (active instanceof Boolean) ? active : true
         if (enabled && SpringSecurityUtils.securityConfig?.active) {
+            "/oauth2/$provider/authenticate"(controller: 'springSecurityOAuth2', action: 'authenticate')
             "/oauth2/$provider/callback"(controller: 'springSecurityOAuth2', action: 'callback')
             "/oauth2/$provider/success"(controller: 'springSecurityOAuth2', action: 'onSuccess')
             "/oauth2/$provider/failure"(controller: 'springSecurityOAuth2', action: 'onFailure')

--- a/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
@@ -126,7 +126,7 @@ class SpringSecurityOauth2BaseService {
      * Register the provider into the service
      * @param providerService
      */
-    def void registerProvider(OAuth2ProviderService providerService) throws OAuth2Exception {
+    void registerProvider(OAuth2ProviderService providerService) throws OAuth2Exception {
         log.debug("Registering provider: " + providerService.getProviderID())
         if (providerServiceMap.containsKey(providerService.getProviderID())) {
             // There is already a provider under that name
@@ -170,7 +170,7 @@ class SpringSecurityOauth2BaseService {
     /**
      * @return The base url
      */
-    def String getBaseUrl() {
+    String getBaseUrl() {
         grailsApplication.config.getProperty('grails.serverURL') ?: "http://localhost:${System.getProperty('server.port', '8080')}${grailsApplication.mainContext.servletContext.contextPath ?: ''}"
     }
 
@@ -178,7 +178,7 @@ class SpringSecurityOauth2BaseService {
      * @param providerName
      * @return The successurl for the provider service
      */
-    def String getSuccessUrl(String providerName) {
+    String getSuccessUrl(String providerName) {
         def providerService = getProviderService(providerName)
         providerService.successUrl ?: baseUrl + "/oauth2/" + providerName + "/success"
     }
@@ -187,7 +187,7 @@ class SpringSecurityOauth2BaseService {
      * @param providerName
      * @return The failureUrl for the provider service
      */
-    def String getFailureUrl(String providerName) {
+    String getFailureUrl(String providerName) {
         def providerService = getProviderService(providerName)
         providerService.failureUrl ?: baseUrl + "/oauth2/" + providerName + "/success"
     }
@@ -205,7 +205,7 @@ class SpringSecurityOauth2BaseService {
      * @param providerID
      * @return An OAuth2AbstractProviderService implementation
      */
-    def OAuth2AbstractProviderService getProviderService(String providerID) {
+    OAuth2AbstractProviderService getProviderService(String providerID) {
         if (!providerServiceMap.get(providerID)) {
             log.error("There is no providerService for " + providerID)
             throw new OAuth2Exception("No provider '${providerID}'")

--- a/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
@@ -170,7 +170,7 @@ class SpringSecurityOauth2BaseService {
      * @return The base url
      */
     def String getBaseUrl() {
-        grailsApplication.config.getProperty('grails.serverURL') ?: "http://localhost:${System.getProperty('server.port', '8080')}"
+        grailsApplication.config.getProperty('grails.serverURL') ?: "http://localhost:${System.getProperty('server.port', '8080')}${grailsApplication.mainContext.servletContext.contextPath ?: ''}"
     }
 
     /**

--- a/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
@@ -15,6 +15,7 @@
 package grails.plugin.springsecurity.oauth2
 
 import com.github.scribejava.core.model.OAuth2AccessToken
+import grails.core.GrailsApplication
 import grails.gorm.transactions.Transactional
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.oauth2.exception.OAuth2Exception
@@ -41,7 +42,7 @@ class SpringSecurityOauth2BaseService {
     Map<String, OAuth2AbstractProviderService> providerServiceMap = new HashMap<>()
     private Map<String, OAuth2ProviderConfiguration> _providerConfigurationMap = new HashMap<>()
 
-    def grailsApplication
+    GrailsApplication grailsApplication
     AuthenticationManager authenticationManager
 
     OAuth2SpringToken createAuthToken(String providerName, OAuth2AccessToken scribeToken) {

--- a/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauth2/SpringSecurityOauth2BaseService.groovy
@@ -61,7 +61,7 @@ class SpringSecurityOauth2BaseService {
      */
     String getAuthorizationUrl(String providerName) {
         OAuth2AbstractProviderService providerService = getProviderService(providerName)
-        providerService.getAuthUrl(['scope': _providerConfigurationMap.get(providerName).scope])
+        providerService.getAuthUrl([:])
     }
 
     /**

--- a/src/main/groovy/grails/plugin/springsecurity/oauth2/service/OAuth2AbstractProviderService.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/oauth2/service/OAuth2AbstractProviderService.groovy
@@ -96,7 +96,11 @@ abstract class OAuth2AbstractProviderService implements OAuth2ProviderService {
      * @return
      */
     String getAuthUrl(Map<String, String> params) {
-        authService.getAuthorizationUrl(params)
+        final String secretState = getProviderID() + "-secret-" + new Random().nextInt(999_999)
+        return authService.createAuthorizationUrlBuilder()
+                .state(secretState)
+                .additionalParams(params)
+                .build()
     }
 
     /**
@@ -105,17 +109,14 @@ abstract class OAuth2AbstractProviderService implements OAuth2ProviderService {
      * @return a scribejava service builder
      */
     OAuth20Service buildScribeService(OAuth2ProviderConfiguration providerConfiguration) {
-        final String secretState = getProviderID() + "-secret-" + new Random().nextInt(999_999)
-        ServiceBuilder serviceBuilder = new ServiceBuilder()
-                .apiKey(providerConfiguration.apiKey)
+        ServiceBuilder serviceBuilder = new ServiceBuilder(providerConfiguration.apiKey)
                 .apiSecret(providerConfiguration.apiSecret)
-                .state(secretState)
         if (providerConfiguration.callbackUrl) {
             serviceBuilder.callback(providerConfiguration.callbackUrl)
         }
-//        if (providerConfiguration.scope) {
-//            serviceBuilder.scope(providerConfiguration.scope)
-//        }
+        if (providerConfiguration.scope) {
+            serviceBuilder.defaultScope(providerConfiguration.scope)
+        }
         if (providerConfiguration.debug) {
             serviceBuilder.debug()
         }
@@ -144,9 +145,9 @@ abstract class OAuth2AbstractProviderService implements OAuth2ProviderService {
      * @return
      */
     Response getResponse(OAuth2AccessToken accessToken) {
-        OAuthRequest oAuthRequest = new OAuthRequest(Verb.GET, getProfileScope(), authService)
-        authService.signRequest(accessToken, oAuthRequest);
-        oAuthRequest.send()
+        OAuthRequest oAuthRequest = new OAuthRequest(Verb.GET, getProfileScope())
+        authService.signRequest(accessToken, oAuthRequest)
+        authService.execute(oAuthRequest)
     }
 
     OAuth20Service getAuthService() {

--- a/src/main/groovy/grails/plugin/springsecurity/oauth2/token/OAuth2SpringToken.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/oauth2/token/OAuth2SpringToken.groovy
@@ -37,7 +37,7 @@ abstract class OAuth2SpringToken extends AbstractAuthenticationToken {
 
     protected OAuth2AccessToken accessToken
     protected Map tokenParams
-    protected Object principal
+    Object principal
     Collection<GrantedAuthority> authorities
 
     /**


### PR DESCRIPTION
This PR is intended to make this plugin fully compatible with Grails 4, without breaking compatibility with current Grails version support (3.3.8).
I have been able to make it successfully run with a new Grails 4.0.0 app.

It contains the following upgrades:

- Upgrade to latest Scribejava release version (6.8.1)
- Upgrade UrlValidator class from deprecated org.grails.validation.* to commons-validator

It also contains the folllowing fixes:

- Fix the oauth callback URL generation when a context path is configured in a localhost environment
- Add an explicit URL mapping for authenticate action (in form of `/oauth2/**`), which does not rely on default application URL mappings

Finally, it contains a few syntactic cleanups.
