### PR TITLE
Update grails-gradle-plugin + spring-security-core to version 6.1.0

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: 8
+          java-version: 11
       - name: Run Build
         id: build
         uses: gradle/gradle-build-action@v2
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: 8
+          java-version: 11
       - name: Publish Artifacts
         id: publish
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: 8
+          java-version: 11
       - name: Set the current release version
         id: release_version
         run: echo ::set-output name=release_version::${GITHUB_REF:11}

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	compileOnly 'org.grails:grails-dependencies'
 	compileOnly "org.grails:grails-plugin-services"
 	api 'com.github.scribejava:scribejava-apis:8.3.3'
-	api 'org.grails.plugins:spring-security-core:5.3.0'
+	api 'org.grails.plugins:spring-security-core:6.1.0'
 
 	console "org.grails:grails-console"
 	profile "org.grails.profiles:web-plugin"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 projectVersion=2.0.1-SNAPSHOT
 grailsVersion=5.3.2
-grailsGradlePluginVersion=5.3.0
+grailsGradlePluginVersion=6.1.0
 groovyVersion=3.0.11
 gorm.version=7.3.3
 vcsUrl=https://github.com/grails/grails-spring-security-oauth2

--- a/src/docs/history.adoc
+++ b/src/docs/history.adoc
@@ -2,7 +2,11 @@
 
 Please read release notes at https://github.com/grails/grails-spring-security-oauth2/releases for checking release information in the future.
 
-* Version 3.0.0
+* Version 2.0.2
+** Upgraded to Spring Security Core 6.1.0
+* Version 2.0.1
+** Update plugin com.gradle.common-custom-user-data-gradle-plugin to v1.12
+* Version 2.0.0
 ** Upgraded to Grails 5.3 with Groovy 3..0.11
 ** Fixed conflict with logback-config library.
 * Version 2.0.0-RC1

--- a/src/docs/history.adoc
+++ b/src/docs/history.adoc
@@ -4,6 +4,7 @@ Please read release notes at https://github.com/grails/grails-spring-security-oa
 
 * Version 2.0.2
 ** Upgraded to Spring Security Core 6.1.0
+** Upgraded to Grails Gradle Plugin 6.1.0
 * Version 2.0.1
 ** Update plugin com.gradle.common-custom-user-data-gradle-plugin to v1.12
 * Version 2.0.0


### PR DESCRIPTION
This PR supersedes https://github.com/grails/grails-spring-security-oauth2/pull/39 + https://github.com/grails/grails-spring-security-oauth2/pull/34

SSC no longer supports Java 8, so we need to drop it from the CI/release workflows too.
